### PR TITLE
Add diffing to refactored upload version

### DIFF
--- a/utils/uploadHelpers.js
+++ b/utils/uploadHelpers.js
@@ -3,8 +3,9 @@ const fs = require("fs");
 const path = require("path");
 const { UPLOAD_PATH, REPOSITORY_PATH } = require("../config/init");
 const { createGitHandler } = require("../services/git");
-const { compareTrackChanges, getDetailedProjectDiff } = require("../utils/trackComparison");
-const { exec } = require("child_process");
+const { compareTrackChanges, getDetailedProjectDiff } = require('../utils/trackComparison');
+const util = require('node:util');
+const exec = util.promisify(require('node:child_process').exec);
 
 /**
  * 
@@ -21,16 +22,11 @@ const createConfiguredBusBoy = (req, res) => {
     let { filename, encoding, mimeType } = fileInfo;
     console.log("Receiving file:", filename);
 
-    if (filename === "blob") {
-      filename = "metadata.json";
-    }
-
     // Collect file data in memory
     const chunks = [];
     fileStream.on("data", (chunk) => {
       chunks.push(chunk);
     });
-
 
     fileStream.on("end", () => {
       const fileBuffer = Buffer.concat(chunks);
@@ -41,8 +37,6 @@ const createConfiguredBusBoy = (req, res) => {
 
       files.push({ fieldname, filename, encoding, mimeType, savePath });
 
-      console.log("File saved to:", savePath);
-
     });
   });
 
@@ -50,100 +44,86 @@ const createConfiguredBusBoy = (req, res) => {
     jsonData[fieldname] = value;
   });
 
-  bb.on("finish", () => {
-
-    console.log("Upload complete");
+  bb.on("finish", async () => {
 
     if (!files.length) {
       return res.status(400).json({ error: "No files uploaded" });
     }
-
-    //read blob file in uploads folder and parse into userId, projectId, commitMessage
-    const blobFilePath = path.join(UPLOAD_PATH, "metadata.json");
-    console.log("Blob file path:", blobFilePath);
-    if (fs.existsSync(blobFilePath)) {
-      try {
-        const blobContent = fs.readFileSync(blobFilePath, "utf8");
-        const blobData = JSON.parse(blobContent);
-        let { userId, projectId, commitMessage } = blobData;
-
-        //exec parseAbleton.py ..uploads/<proj>.als ../utils/repo/repository/userId/projectId
-        console.log("Parsed blob data:", { userId, projectId, commitMessage });
-        //exec parseAbleton.py ..uploads/<proj>.als ../utils/repo/repository/userId/projectId
-        const pythonScriptPath = path.join(__dirname, "../utils/parseAbleton.py");
-        const alsFilePath = path.join(UPLOAD_PATH);
-        const repoPath = path.join(REPOSITORY_PATH, projectId);
-
-        // copy the als file to the repo path it ends with .als
-        const alsFileName = files.find(file => file.filename.endsWith('.als')).filename;
-        const alsFileSrcPath = path.join(UPLOAD_PATH, alsFileName);
-        const alsFileDestPath = path.join(repoPath, alsFileName);
-
-        const command = `python3 ${pythonScriptPath} ${alsFilePath} ${repoPath}`;
-        
-        //before executing the command, store the current ableton_project.json
-        const previousJsonPath = path.join(repoPath, 'ableton_project.json');
-        let previousJson = null;
-        if (fs.existsSync(previousJsonPath)) {
-          previousJson = fs.readFileSync(previousJsonPath, 'utf8');
-        }
-        
-        console.log("Executing command:", command);
-      exec(command, async (error, stdout, stderr) => {
-          if (error) {
-            console.error("Error executing script:", error);
-            return;
-          }
-          console.log("Script output:", stdout);
-          console.error("Script error output:", stderr);
-        
-          const repoPath = path.join(REPOSITORY_PATH, projectId);
-          const git = await createGitHandler(repoPath);
-          
-        
-          // Get current ableton_project.json
-          const currentJsonPath = path.join(repoPath, 'ableton_project.json');
-          const currentJson = fs.readFileSync(currentJsonPath, 'utf8');
-        
-          // Compare versions and detect changes
-          let trackChanges = null;
-          if (previousJson) {
-            trackChanges = compareTrackChanges(previousJson, currentJson);
-          }
-
-          if( !trackChanges || trackChanges.length === 0) {
-            console.log("No changes detected in the project.");
-            return res.status(200).json({
-              message: "No changes detected, no commit made.",
-              files,
-              jsonData,
-            });
-          }
-
-          // If changes detected, get detailed project diff
-          const detailedDiff = getDetailedProjectDiff(previousJson, currentJson);
-          console.log("Detailed project diff:", detailedDiff);
-
-          //create a file called diff.json in the repoPath
-          const diffFilePath = path.join(repoPath, 'diff.json');
-          fs.writeFileSync(diffFilePath, JSON.stringify(detailedDiff, null, 2));
-          console.log("Detailed diff saved to:", diffFilePath);
-        
-          fs.copyFileSync(alsFileSrcPath, alsFileDestPath);
-          git.commitAbletonUpdate(userId, commitMessage, trackChanges);
-
-          res.status(201).json({
-            message: "Files uploaded successfully",
-            files,
-            jsonData,
-          });
-        });
-
-
-      } catch (err) {
-        console.error("Error reading blob file:", err);
-      }
+    let { userId, projectId, commitMessage } = jsonData;
+    if (!userId || !projectId) {
+      return res.status(400).json({
+        error: "Missing required metadata:",
+        userId: userId,
+        projectId: projectId
+      })
     }
+
+    //exec parseAbleton.py ..uploads/<proj>.als ../utils/repo/repository/userId/projectId
+    const pythonScriptPath = path.join(__dirname, "../utils/parseAbleton.py");
+    const alsFilePath = path.join(UPLOAD_PATH);
+    const repoPath = path.join(REPOSITORY_PATH, projectId);
+    try {
+      // copy the als file to the repo path it ends with .als
+      const alsFileName = files.find(file => file.filename.endsWith('.als')).filename;
+      const alsFileSrcPath = path.join(UPLOAD_PATH, alsFileName);
+      const alsFileDestPath = path.join(repoPath, alsFileName);
+
+      const command = `python3 ${pythonScriptPath} ${alsFilePath} ${repoPath}`;
+
+      //before executing the command, store the current ableton_project.json
+      const previousJsonPath = path.join(repoPath, 'ableton_project.json');
+      let previousJson = null;
+      if (fs.existsSync(previousJsonPath)) {
+        previousJson = fs.readFileSync(previousJsonPath, 'utf8');
+      }
+
+      try {
+        const { stdout, stderr } = await exec(command);
+        console.log('Script output:', stdout);
+        console.log('Script error output:', stderr);
+      } catch (error) {
+        console.log('Error executing script:', error);
+        res.status(500).json({
+          message: "Error executing parser script",
+          files,
+          jsonData,
+        })
+      }
+      const git = await createGitHandler(repoPath);
+
+      fs.copyFileSync(alsFileSrcPath, alsFileDestPath);
+      // Get current ableton_project.json
+      const currentJsonPath = path.join(repoPath, 'ableton_project.json');
+      const currentJson = fs.readFileSync(currentJsonPath, 'utf8');
+
+      // Compare versions and detect changes
+      let trackChanges = null;
+      if (previousJson) {
+        trackChanges = compareTrackChanges(previousJson, currentJson);
+
+        const detailedDiff = getDetailedProjectDiff(previousJson, currentJson);
+        console.log("Detailed project diff:", detailedDiff);
+        const diffFilePath = path.join(repoPath, 'diff.json');
+        fs.writeFileSync(diffFilePath, JSON.stringify(detailedDiff, null, 2));
+        console.log("Detailed diff saved to:", diffFilePath);
+      }
+
+
+      git.commitAbletonUpdate(userId, commitMessage, trackChanges);
+      res.status(201).json({
+        message: "Files uploaded successfully",
+        files,
+        jsonData,
+      });
+    } catch (err) {
+      console.error("Error:", err);
+      res.status(500).json({
+        message: err,
+        files,
+        jsonData,
+      })
+    }
+
   });
   return bb;
 }


### PR DESCRIPTION
## Overview

The upload_bug branch used the old code for uploadHelpers.js.
This branch used the refactored version  with a minor adjustment to fix a bug.

## Why the refactor
The refactored version includes
- Better error handling, e.g, rather than just returning when an error occurs, we end the response with a status code and a message indicating the error.
- promise-based exec, which avoids nesting and makes the code more readable. 

The refactored code makes it easier to just modify the upload endpoint to also include collab requests.

## Handling Bug
Bug: on initial commit, there is no previous json file that can be used for diffing, so the handler returns without making the first commit.

The differences in how the bug was handled:

- In upload_branch, new variables were added to check whether this commit would be the first and whether there are any track changes.
- In this branch, we do not consider whether the commit would be the first or not.
If there was no previous json, we just don't do any diffing and commit.  If there was a previous json, then we do the diffing and commit. If the diffing shows that there are no track changes, then committing wouldn't do anything. 